### PR TITLE
fix: update samplewise radiomic outputs to handle multi-ROI samples

### DIFF
--- a/config/pyradiomics/pyradiomics_h4h_all_images_features.yaml
+++ b/config/pyradiomics/pyradiomics_h4h_all_images_features.yaml
@@ -1,0 +1,50 @@
+imageType:
+    Original: {}
+    Wavelet: {}
+    Square: {}
+    SquareRoot: {}
+    Logarithm: {}
+    Exponential: {}
+    Gradient: {}
+
+featureClass:
+    shape:
+        - VoxelVolume
+        - MeshVolume
+        - SurfaceArea
+        - SurfaceVolumeRatio
+        - Compactness1
+        - Sphericity
+        - Maximum3DDiameter
+        - Maximum2DDiameterSlice
+        - Maximum2DDiameterColumn
+        - Maximum2DDiameterRow
+        - MajorAxisLength
+        - MinorAxisLength
+        - LeastAxisLength
+        - Elongation
+        - Flatness
+    firstorder:
+    glcm: 
+    glrlm: 
+    glszm: 
+    gldm:
+    ngtdm: 
+
+setting:
+    minimumROIDimensions: 2 
+    minimumROISize: None 
+    normalize: False 
+    normalizeScale: 1 
+    removeOutliers: None 
+    resampledPixelSpacing: [1.0 1.0 1.0] 
+    interpolator: sitkBSpline 
+    preCrop: False 
+    padDistance: 5 
+    distances: [1] 
+    force2D: False 
+    force2Ddimension: 0 
+    resegmentRange: None 
+    label: 1 
+    additionalInfo: True 
+    binWidth: 25

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -1,5 +1,18 @@
 # Data Sources
 
+## CC-Radiomics-Phantom
+- **Name**: Credence Cartridge Radiomics Phantom CT Scans
+- **Version/Date**: Version 1: Updated 2017/07/28
+- **URL**: <https://www.cancerimagingarchive.net/collection/cc-radiomics-phantom/>
+- **Access Method**: NBIA Data Retriever
+- **Access Date**: 2025-04-22
+- **Data Format**: DICOM
+- **Citation**: Mackin, D., Ray, X., Zhang, L., Fried, D., Yang, J., Taylor, B., Rodriguez-Rivera, E., Dodge, C., Jones, A., & Court, L. (2017). Data From Credence Cartridge Radiomics Phantom CT Scans (CC-Radiomics-Phantom) [Data set]. The Cancer Imaging Archive. https://doi.org/10.7937/K9/TCIA.2017.zuzrml5b 
+- **License**: [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)
+
+Image Types: CT, RTSTRUCT
+
+
 ## Overview
 
 This section should document all data sources used in your project.

--- a/workflow/scripts/pyradiomics_index.py
+++ b/workflow/scripts/pyradiomics_index.py
@@ -11,8 +11,15 @@ def generate_dataset_index(image_directory:Path,
     # Get list of sample IDs from top of data directory
     unique_sample_ids = [sample_dir.name for sample_dir in sorted(image_directory.glob(pattern="*/"))]
 
-    # Construct dataframe to iterate over
-    dataset_index = pd.DataFrame(data = {'ID': unique_sample_ids, 'Image': image_files, 'Mask': mask_files})
+    if len(mask_files) > len(image_files):
+        mask_index = pd.DataFrame(data= {'ID': [mask_path.parent.parent.stem for mask_path in mask_files],
+                                         'Mask': mask_files})
+        image_index = pd.DataFrame(data = {'ID': unique_sample_ids, 'Image': image_files})
+        dataset_index = image_index.merge(mask_index, how='outer', left_on='ID', right_on='ID')
+
+    else:
+        # Construct dataframe to iterate over
+        dataset_index = pd.DataFrame(data = {'ID': unique_sample_ids, 'Image': image_files, 'Mask': mask_files})
 
     dataset_index.to_csv(output_file_path, index=False)
 
@@ -26,7 +33,7 @@ if __name__ == "__main__":
     RESULTS_DATA_PATH = DATA_DIR_PATH / "results"
 
     DATA_SOURCE = "TCIA"
-    DATASET_NAME = "HEAD-NECK-RADIOMICS-HN1"
+    DATASET_NAME = "CC-Radiomics-Phantom"
 
     dataset = f"{DATA_SOURCE}_{DATASET_NAME}"
 

--- a/workflow/scripts/run_readii.py
+++ b/workflow/scripts/run_readii.py
@@ -28,11 +28,11 @@ def pyradiomics_extraction(extractor:radiomics.featureextractor,
                            ):
     # check if file already exists
     if region and transform:
-        sample_result_file_name = f"{sample_info.ID}_{region}_{transform}_features.csv"
+        sample_result_file_name = f"{region}_{transform}_features.csv"
     else:
-        sample_result_file_name = f"{sample_info.ID}_full_original_features.csv"
+        sample_result_file_name = f"full_original_features.csv"
     
-    complete_out_path = sample_dir_path / sample_result_file_name
+    complete_out_path = sample_dir_path / sample_result_file_name 
     if complete_out_path.exists() and (not overwrite):
         print(f"Features already extracted for: {complete_out_path.stem}")
         return
@@ -124,7 +124,8 @@ def main(dataset_index:pd.DataFrame,
 
     for idx, sample_row in tqdm(dataset_index.iterrows(), total=len(dataset_index)):
         # Set up output dir for this sample's features
-        sample_feature_dir = procdata_path / Path(pyrad_params).stem / sample_row.ID
+        roi_name = Path(Path(sample_row.Mask).stem).stem
+        sample_feature_dir = procdata_path / Path(pyrad_params).stem / sample_row.ID / roi_name
         sample_feature_dir.mkdir(parents=True, exist_ok=True)
 
         # Load image and ROI mask for this sample
@@ -185,7 +186,7 @@ if __name__ == "__main__":
 
     # specific dataset path setup
     DATA_SOURCE = "TCIA"
-    DATASET_NAME = "NSCLC-Radiomics"
+    DATASET_NAME = "CC-Radiomics-Phantom"
     
     dataset = f"{DATA_SOURCE}_{DATASET_NAME}"
     dataset_index_path = PROC_DATA_PATH / dataset / f"pyrad_{dataset}_index.csv"

--- a/workflow/scripts/run_readii.py
+++ b/workflow/scripts/run_readii.py
@@ -64,7 +64,7 @@ def combine_feature_results(nc_manager:NegativeControlManager,
         strategy_list.append(f"{strategy_combo[1].region_name}_{strategy_combo[0].negative_control_name}")
 
     for negative_control in strategy_list:
-        feature_file_list = sorted(samplewise_feature_dir_path.rglob(f"*[0-9]_{negative_control}_features.csv"))
+        feature_file_list = sorted(samplewise_feature_dir_path.rglob(f"*{negative_control}_features.csv"))
 
         combined_feature_path = output_dir_path / f"{negative_control}_features.csv"
         combined_feature_path.parent.mkdir(parents=True, exist_ok=True)
@@ -200,10 +200,10 @@ if __name__ == "__main__":
                           pyrad_params = parameter_file_path,
                           procdata_path = PROC_DATA_PATH / dataset,
                           results_path = RESULTS_DATA_PATH / dataset,
-                          regions = ["full", "roi"],
+                          regions = ["non_roi"],
                           transforms = ["shuffled", "sampled", "randomized"],
                           overwrite = False,
-                          parallel = True,
+                          parallel = False,
                           seed = RANDOM_SEED)
     
 


### PR DESCRIPTION
Original code was overwriting the single sample radiomic output files, so now features are saved in a `sample/ROI_name/negative_control_features.csv` structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive PyRadiomics configuration for extracting shape features from multiple image types.

- **Documentation**
  - Added a new section detailing the CC-Radiomics-Phantom dataset, including metadata, access instructions, and citation.

- **Bug Fixes**
  - Improved dataset indexing to handle cases where there are more mask files than image files.

- **Chores**
  - Updated dataset names and file organization for feature extraction outputs.
  - Adjusted default regions and disabled parallel execution in feature extraction scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->