### PR TITLE
refactor: move MIT rules to dedicated rule file

### DIFF
--- a/config/datasets/NSCLC-Radiomics_test.yaml
+++ b/config/datasets/NSCLC-Radiomics_test.yaml
@@ -13,11 +13,11 @@ CLINICAL:
 
 ### MED-IMAGETOOLS settings
 MIT:
-    #COMMAND: "imgtools autopipeline ~/bhklab/radiomics/PublicDatasets/srcdata/HeadNeck/TCIA_HEAD-NECK-RADIOMICS-HN1/images/HEAD-NECK-RADIOMICS-HN1/unzipped/ ~/bhklab/radiomics/PublicDatasets/procdata/HeadNeck/TCIA_HEAD-NECK-RADIOMICS-HN1/mit2_HEAD-NECK-RADIOMICS-HN1 --modalities \"CT,RTSTRUCT\" -rmap \"GTV:GTV-1\" --roi-strategy MERGE --update-crawl -f {PatientID}_{SampleNumber}/{Modality}_{SeriesInstanceUID}/{ImageID}.nii.gz"
+    ROI_STRATEGY: MERGE
     ROI_MATCH_MAP:
         GTV:GTV-1
     MODALITIES: CT,RTSTRUCT
-    INDEX_FILE: "mit_NSCLC-Radiomics_test_index.csv"
+    
 
 ### READII settings
 READII:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,6 +8,7 @@ COMBINED_DATA_NAME = config["DATA_SOURCE"] + "_" + config["DATASET_NAME"]
 include: "scripts/mit/run_mit.smk"
 
 rule run_mit:
+    # Target rule - coordinates MIT processing workflow
     input:
         mit_autopipeline_index=dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}" / f"mit_{config["DATASET_NAME"]}_index.csv",
         mit_niftis_directory=dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,44 +1,19 @@
 from damply import dirs as dmpdirs
-from pathlib import Path
-import pandas as pd
 
 # could alternatively pass this in the CLI via `--configfile $CONFIG/config.yaml`
 # configfile: dmpdirs.CONFIG / "datasets" / "NSCLC-Radiomics_test.yaml"
 
 COMBINED_DATA_NAME = config["DATA_SOURCE"] + "_" + config["DATASET_NAME"]
 
+include: "scripts/mit/run_mit.smk"
 
-rule run_mit_autopipeline:
+rule run_mit:
     input:
-        input_directory=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images" / config["DATASET_NAME"],
-        mit_crawl_index=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images/.imgtools" / config["DATASET_NAME"] / "index.csv"
-    output:
         mit_autopipeline_index=dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}" / f"mit_{config["DATASET_NAME"]}_index.csv",
-        output_directory=directory(dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}")
-    params:
-        modalities=config["MIT"]["MODALITIES"],
-        roi_match_map=config["MIT"]["ROI_MATCH_MAP"]
-        roi_strategy=config["MIT"]["ROI_STRATEGY"]
-    shell:
-        """
-        imgtools autopipeline {input.input_directory} {output.output_directory} \
-        --modalities {params.modalities} \
-        --roi-match-map {params.roi_match_map} \
-        --roi-strategy {params.roi_strategy} \
-        --filename-format "{{PatientID}}_{{SampleNumber}}/{{Modality}}_{{SeriesInstanceUID}}/{{ImageID}}.nii.gz"
-        """
+        mit_niftis_directory=dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}"
 
 
-rule run_mit_index:
-    input:
-        dicom_dir=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images" / config["DATASET_NAME"]
-    output:
-        directory(dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images/.imgtools" / config["DATASET_NAME"]),
-        mit_crawl_index=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images/.imgtools" / config["DATASET_NAME"] / "index.csv"
-    params:
-        dataset_name= config["DATASET_NAME"]
-    shell:
-        """
-        imgtools index --dicom-dir {input.dicom_dir} --dataset-name {params.dataset_name} --force
-        """
+
+
+
 

--- a/workflow/scripts/mit/run_mit.smk
+++ b/workflow/scripts/mit/run_mit.smk
@@ -1,0 +1,34 @@
+from damply import dirs as dmpdirs
+
+rule run_mit_autopipeline:
+    input:
+        input_directory=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images" / config["DATASET_NAME"],
+        mit_crawl_index=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images/.imgtools" / config["DATASET_NAME"] / "index.csv"
+    output:
+        mit_autopipeline_index=dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}" / f"mit_{config["DATASET_NAME"]}_index.csv",
+        output_directory=directory(dmpdirs.PROCDATA / COMBINED_DATA_NAME / "images" / f"mit_{config["DATASET_NAME"]}")
+    params:
+        modalities=config["MIT"]["MODALITIES"],
+        roi_match_map=config["MIT"]["ROI_MATCH_MAP"],
+        roi_strategy=config["MIT"]["ROI_STRATEGY"]
+    shell:
+        """
+        imgtools autopipeline {input.input_directory} {output.output_directory} \
+        --modalities {params.modalities} \
+        --roi-match-map {params.roi_match_map} \
+        --roi-strategy {params.roi_strategy} \
+        --filename-format "{{PatientID}}_{{SampleNumber}}/{{Modality}}_{{SeriesInstanceUID}}/{{ImageID}}.nii.gz"
+        """
+
+rule run_mit_index:
+    input:
+        dicom_dir=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images" / config["DATASET_NAME"]
+    output:
+        directory(dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images/.imgtools" / config["DATASET_NAME"]),
+        mit_crawl_index=dmpdirs.RAWDATA / COMBINED_DATA_NAME / "images/.imgtools" / config["DATASET_NAME"] / "index.csv"
+    params:
+        dataset_name= config["DATASET_NAME"]
+    shell:
+        """
+        imgtools index --dicom-dir {input.dicom_dir} --dataset-name {params.dataset_name} --force
+        """


### PR DESCRIPTION
Set up so each step of pipeline can be put in Snakefile, but each process can have it's own rule file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a modular and hierarchical configuration format for datasets, improving clarity and flexibility.
  - Added new example and template configuration files for datasets.
  - Added a Snakemake workflow and supporting scripts for automated medical imaging data processing.
  - Provided a sample Jupyter notebook and Python script demonstrating environment setup and directory inspection.
  - Enhanced environment setup with new variables and dependencies for streamlined project management.

- **Documentation**
  - Updated and expanded documentation to reflect new configuration formats and workflow structure.

- **Chores**
  - Updated `.gitignore` to exclude `.snakemake` files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->