### PR TITLE
fix: correct mixed usage of single and double quotes in make_negative_control

### DIFF
--- a/src/readii_2_roqc/readii/make_negative_controls.py
+++ b/src/readii_2_roqc/readii/make_negative_controls.py
@@ -100,7 +100,7 @@ def image_preprocessor(dataset_config:dict,
     # make image identifier string for file writer
     image_meta_id = f"{image_path.parent.name}"
     # make mask identifier string for file writer
-    mask_meta_id = f"{mask_path.parent.name}/{mask_image_id.replace(' ', "_")}"
+    mask_meta_id = f"{mask_path.parent.name}/{mask_image_id.replace(' ', '_')}"
     
     # Get beginning of the path to the nifti images dir
     mit_images_dir = images_dir_path / f'mit_{dataset_name}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of spaces in generated mask metadata identifiers by consistently replacing spaces with underscores. This improves identifier consistency, prevents unexpected naming, and reduces downstream issues in image preprocessing workflows (e.g., mismatches or lookup failures when referencing masks).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->