### PR TITLE
feat: add split to output path for labelled features

### DIFF
--- a/sandbox/label_data_for_prediction.ipynb
+++ b/sandbox/label_data_for_prediction.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "10315f6c",
    "metadata": {},
    "outputs": [],
@@ -53,6 +53,8 @@
     "        message = \"No outcome label specifications have been set. Must set either standard_event_label or standard_time_label to proceed.\"\n",
     "        raise ValueError(message)\n",
     "\n",
+    "    split_string = '' if split is None else split\n",
+    "\n",
     "    # Load the dataset configuration file and set up the dataset name versions\n",
     "    dataset_config, _dataset_name, full_data_name = load_dataset_config(dataset)\n",
     "\n",
@@ -77,7 +79,7 @@
     "        labels_and_features = pd.concat([outcome_data, feature_data], axis=1)\n",
     "\n",
     "        # Set up path for and save out labelled feature data\n",
-    "        out_path = feature_file_path.parent.parent / \"labelled\" / f\"{signature}_{outcome_name}\" / f\"{image_type}_labelled_features.csv\"\n",
+    "        out_path = feature_file_path.parent.parent / \"labelled\" / f\"{signature}_{outcome_name}\" / split_string / f\"{image_type}_labelled_features.csv\"\n",
     "\n",
     "        if not out_path.exists() or overwrite:\n",
     "            out_path.parent.mkdir(parents=True, exist_ok=True)\n",
@@ -91,14 +93,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "b6f7da0c",
    "metadata": {},
    "outputs": [],
    "source": [
     "dataset = \"RADCURE_windowed\"\n",
     "signature = \"choi_opc_hpv_2020\"\n",
-    "split = None\n",
+    "split = 'TEST'\n",
     "\n",
     "labelled_data = label_data_for_prediction(dataset, signature, split, standard_event_label='hpv_status')"
    ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Output data directory structure now organizes labeled features into subdirectories based on the split parameter, improving how data is categorized across different dataset splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->