### PR TITLE
feat: add simple extraction script

### DIFF
--- a/simple_extraction.py
+++ b/simple_extraction.py
@@ -15,9 +15,9 @@ from readii_2_roqc.feature_extraction.index import get_mit_extraction_index
 
 def extract_one_pyradiomics(
         sample_data: pd.Series,
-        extraction_settings: str,
-        nifti_images_dir_path: str,
-        output_features_path: str,
+        extraction_settings: Path,
+        nifti_images_dir_path: Path,
+        output_features_path: Path,
         overwrite: bool = False
 ) -> dict[str, str]:
     """Extract features from a single scan and mask pair using pyradiomics."""
@@ -54,7 +54,7 @@ def simple_extraction(
     
     CONFIG_FILE is the path to the dataset configuration file (YAML format).
 
-    NIFTI_DIR is the path to the directory containing med-imagetools converted NIfTI images. Must contain an index-simple.csv file.
+    NIFTI_DIR is the path to the directory containing med-imagetools converted NIfTI images. Must contain an {stem}_index-simple.csv file.
 
     FEATURE_DIR is the path to the directory where extracted features will be saved.
 

--- a/simple_extraction.py
+++ b/simple_extraction.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import click
+import pandas as pd
+import yaml
+from joblib import Parallel, delayed
+from tqdm import tqdm
+
+from readii_2_roqc.feature_extraction.extract import (
+    extract_sample_features,
+    metadata_setup,
+)
+from readii_2_roqc.feature_extraction.index import get_mit_extraction_index
+
+
+def extract_one_pyradiomics(
+        sample_data: pd.Series,
+        extraction_settings: str,
+        nifti_images_dir_path: str,
+        output_features_path: str,
+        overwrite: bool = False
+) -> dict[str, str]:
+    """Extract features from a single scan and mask pair using pyradiomics."""
+    # Set up metadata for the sample
+    metadata = metadata_setup(sample_data)
+
+    sample_feature_vector = extract_sample_features(sample_data=sample_data,
+                                                    method='pyradiomics',
+                                                    settings=extraction_settings,
+                                                    data_dir=nifti_images_dir_path.parent,
+                                                    feature_dir=output_features_path,
+                                                    overwrite=overwrite)
+    # Add sample metadata to the feature vector for this sample
+    metadata.update(sample_feature_vector)
+
+    return metadata
+
+@click.command()
+@click.argument('config_file', type=Path)
+@click.argument('nifti_dir', type=Path)
+@click.argument('feature_dir', type=Path)
+@click.argument('extract_settings', type=Path)
+@click.option('--n_jobs', default=-1, help='Number of parallel jobs to use')
+@click.option('--overwrite', is_flag=True, help='Overwrite existing feature files')
+def simple_extraction(
+    config_file: str,
+    nifti_dir: Path,
+    feature_dir: Path,
+    extract_settings: Path,
+    n_jobs: int = -1,
+    overwrite: bool = False
+)-> None:
+    """Extract features from a dataset using pyradiomics.
+    
+    CONFIG_FILE is the path to the dataset configuration file (YAML format).
+
+    NIFTI_DIR is the path to the directory containing med-imagetools converted NIfTI images. Must contain an index-simple.csv file.
+
+    FEATURE_DIR is the path to the directory where extracted features will be saved.
+
+    EXTRACT_SETTINGS is the path to the extraction settings file (YAML format). 
+    """
+    # Load dataset configuration
+    with config_file.open("r") as f:
+        dataset_config = yaml.safe_load(f)
+
+    # Set up and save out the index file to run feature extraction with
+    mit_simple_index_path = nifti_dir / f"{nifti_dir.stem}_index-simple.csv"
+    extraction_index = get_mit_extraction_index(dataset_config, mit_simple_index_path)
+    if 'DataSource' not in extraction_index.columns:
+        extraction_index['DataSource'] = 'SourceNotSpecified'
+
+    # Save out the extraction index to the output features path
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    extraction_index.to_csv(feature_dir / "pyradiomics_extraction_index.csv", index=False)
+
+    # extract features in parallel for each sample in the extraction index
+    feature_vectors = Parallel(n_jobs=n_jobs)(
+        delayed(extract_one_pyradiomics)(
+            sample_data=sample_data,
+            extraction_settings=extract_settings,
+            nifti_images_dir_path=nifti_dir,
+            output_features_path=feature_dir,
+            overwrite=overwrite
+        )
+        for _, sample_data in tqdm(
+            extraction_index.iterrows(),
+            desc="Extracting pyradiomics features",
+            total=len(extraction_index)
+        )
+    )
+
+    # Concatenate all the feature vectors
+    features_df = pd.DataFrame.from_dict(feature_vectors)
+    # # Save out the features to a single CSV
+    features_df.to_csv(feature_dir / "pyradiomics_features.csv", index=False)
+
+
+if __name__ == "__main__":
+    simple_extraction()

--- a/src/readii_2_roqc/feature_extraction/extract.py
+++ b/src/readii_2_roqc/feature_extraction/extract.py
@@ -106,10 +106,22 @@ def pyradiomics_extract(settings: Path | str,
     
     Parameters
     ----------
-    
+    settings : Path | str
+        Path to the settings file for PyRadiomics feature extraction. Can be a pathlib.Path or a string.
+    image : sitk.Image
+        SimpleITK image object to extract features from.
+    mask : sitk.Image
+        SimpleITK mask object to extract features from.
+    metadata : OrderedDict | dict[str, str] | pd.Series | None
+        Metadata for the sample being extracted. Used to construct output path and save out metadata with features
+    feature_dir : Path | None
+        Path to the directory where features will be saved. If None, will use default path based on metadata and settings.
+    overwrite : bool
+        Whether to overwrite existing feature files. If False and feature file exists, will load existing features and return them instead of re-extracting.
     Returns
     -------
-
+    pd.Series
+        Extracted features as a pandas Series object. If overwrite is False and feature file exists, will load existing features and return them instead of re-extracting.
     """
     # Set PyRadiomics verbosity to critical only
     setVerbosity(50)
@@ -198,7 +210,7 @@ def extract_sample_features(sample_data: pd.Series,
     method : str
         The feature extraction method to use.
     settings : str
-        Name of the settings file for the feature extraction method. Should be in the config/<method> directory.
+        Path to the settings file for the feature extraction method. 
     overwrite : bool
         Whether to overwrite existing feature files.
 
@@ -208,9 +220,8 @@ def extract_sample_features(sample_data: pd.Series,
         The extracted features for the sample. No metadata will be prepended to this vector.
     """
     # Set up settings file path for the feature extraction method
-    settings_path = dirs.CONFIG / method / settings
-    if not settings_path.exists():
-        message = f"Settings file for {method} feature extraction does not exist at {settings_path}."
+    if not settings.exists():
+        message = f"Settings file for {method} feature extraction does not exist at {settings}."
         logger.error(message)
         raise FileNotFoundError(message)
     
@@ -223,7 +234,7 @@ def extract_sample_features(sample_data: pd.Series,
     match method:
         case "pyradiomics":
             # Extract features using PyRadiomics
-            sample_feature_vector = pyradiomics_extract(settings=settings_path,
+            sample_feature_vector = pyradiomics_extract(settings=settings,
                                                         image=image,
                                                         mask=mask,
                                                         metadata=sample_data,
@@ -438,6 +449,8 @@ def extract_dataset_features(dataset: str,
             message = 'No crop methods have been implemented for PyRadiomics extraction with READII yet.'
             logger.error(message)
             raise NotImplementedError(message)
+
+
 
     logger.info("Starting feature extraction for individual image type + mask pairs.")
     # Extract features for each sample in the dataset index

--- a/src/readii_2_roqc/feature_extraction/extract.py
+++ b/src/readii_2_roqc/feature_extraction/extract.py
@@ -220,7 +220,7 @@ def extract_sample_features(sample_data: pd.Series,
         The extracted features for the sample. No metadata will be prepended to this vector.
     """
     # Set up settings file path for the feature extraction method
-    if not settings.exists():
+    if not Path(settings).exists():
         message = f"Settings file for {method} feature extraction does not exist at {settings}."
         logger.error(message)
         raise FileNotFoundError(message)

--- a/src/readii_2_roqc/feature_extraction/extract.py
+++ b/src/readii_2_roqc/feature_extraction/extract.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 def sample_feature_writer(feature_vector : OrderedDict,
                           metadata : dict[str, str],
                           extraction_method: str,
-                          extraction_settings_name : str
+                          extraction_settings_name : str,
+                          feature_dir: Path | None = None
                           ) -> OrderedDict[str, str]:
     """Write out the feature vector and metadata to a csv file.
     
@@ -44,7 +45,8 @@ def sample_feature_writer(feature_vector : OrderedDict,
     image_size_str = remove_slice_index_from_string(metadata['readii_Resize'])
     
     # Construct output path with elements from metadata
-    output_path = dirs.PROCDATA / f"{metadata['DataSource']}_{metadata['DatasetName']}" / "features" / extraction_method / image_size_str / extraction_settings_name / metadata['SampleID'] / metadata['MaskID'] / f"{metadata['readii_Permutation']}_{metadata['readii_Region']}_features.csv"
+    feature_dir = dirs.PROCDATA / f"{metadata['DataSource']}_{metadata['DatasetName']}" / "features" / extraction_method / image_size_str / extraction_settings_name if feature_dir is None else feature_dir
+    output_path = feature_dir / metadata['SampleID'] / metadata['MaskID'] / f"{metadata['readii_Permutation']}_{metadata['readii_Region']}_features.csv"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Set up metadata as an OrderedDict to be combined with the features
@@ -97,6 +99,7 @@ def pyradiomics_extract(settings: Path | str,
                         image: sitk.Image,
                         mask: sitk.Image,
                         metadata : OrderedDict | dict[str, str] | pd.Series | None = None,
+                        feature_dir: Path | None = None,
                         overwrite : bool = False
                         ) -> pd.Series:
     """Extract PyRadiomic features from an image and mask pair based on configuration from settings file.
@@ -118,7 +121,8 @@ def pyradiomics_extract(settings: Path | str,
     image_size_str = remove_slice_index_from_string(metadata["readii_Resize"])
 
     # Check if feature file already exists and if overwrite is specified
-    sample_feature_file_path = dirs.PROCDATA / f"{metadata['DataSource']}_{metadata['DatasetName']}" / "features" / "pyradiomics" / image_size_str / Path(settings).stem / metadata['SampleID'] / metadata['MaskID'] / f"{metadata['readii_Permutation']}_{metadata['readii_Region']}_features.csv"
+    feature_dir = dirs.PROCDATA / f"{metadata['DataSource']}_{metadata['DatasetName']}" / "features" / "pyradiomics" / image_size_str / Path(settings).stem  if feature_dir is None else feature_dir
+    sample_feature_file_path = feature_dir / metadata['SampleID'] / metadata['MaskID'] / f"{metadata['readii_Permutation']}_{metadata['readii_Region']}_features.csv"
     if sample_feature_file_path.exists() and not overwrite:
         logger.info(f"Features for {metadata['SampleID']} {metadata['readii_Permutation']} {metadata['readii_Region']} {metadata['Modality_Image']} image and {metadata['MaskID']} mask have already been extracted.")
         # Load the existing feature file
@@ -156,7 +160,8 @@ def pyradiomics_extract(settings: Path | str,
             sample_feature_writer(feature_vector=sample_feature_vector,
                                 metadata=metadata,
                                 extraction_method="pyradiomics",
-                                extraction_settings_name=Path(settings).stem)
+                                extraction_settings_name=Path(settings).stem,
+                                feature_dir=feature_dir)
 
     # Returning this vector of features on its own with no metadata on the front
     return sample_feature_vector
@@ -166,6 +171,8 @@ def pyradiomics_extract(settings: Path | str,
 def extract_sample_features(sample_data: pd.Series,
                             method: str,
                             settings: Path | str,
+                            data_dir: Path | None = None,
+                            feature_dir: Path | None = None,
                             overwrite: bool = False) -> OrderedDict:
     """Extract features from a single sample using the specified method and settings.
 
@@ -207,10 +214,11 @@ def extract_sample_features(sample_data: pd.Series,
         logger.error(message)
         raise FileNotFoundError(message)
     
-    data_dir = dirs.PROCDATA / f"{sample_data['DataSource']}_{sample_data['DatasetName']}" / "images"
+    data_dir = dirs.PROCDATA / f"{sample_data['DataSource']}_{sample_data['DatasetName']}" / "images" if data_dir is None else data_dir
 
     image = sitk.ReadImage(data_dir / sample_data['Image'])
     mask = sitk.ReadImage(data_dir / sample_data['Mask'])
+    mask.SetOrigin(image.GetOrigin())
 
     match method:
         case "pyradiomics":
@@ -219,6 +227,7 @@ def extract_sample_features(sample_data: pd.Series,
                                                         image=image,
                                                         mask=mask,
                                                         metadata=sample_data,
+                                                        feature_dir=feature_dir,
                                                         overwrite=overwrite)
         case _:
             message = f"Feature extraction method {method} is not implemented yet."

--- a/src/readii_2_roqc/feature_extraction/index.py
+++ b/src/readii_2_roqc/feature_extraction/index.py
@@ -102,10 +102,10 @@ def get_readii_extraction_index(dataset_config: dict,
     ----------
     dataset_config : dict
         Configuration settings for a dataset, loaded with loadImageDatasetConfig
-    readii_index : pd.DataFrame
-        DataFrame containing metadata for the images and masks processed by READII make_negative_controls
-    mit_index : pd.DataFrame | None
-        DataFrame containing metadata for the MIT processed images and masks
+    readii_index_path : Path
+        Path to file containing metadata for the images and masks processed by READII make_negative_controls
+    mit_index_path : Path | None
+        Path to file containing metadata for the MIT processed images and masks
 
     Returns
     -------

--- a/src/readii_2_roqc/feature_extraction/index.py
+++ b/src/readii_2_roqc/feature_extraction/index.py
@@ -70,12 +70,13 @@ def get_mit_extraction_index(dataset_config: dict,
 
     # Get single row for each image and mask pair
     mit_edges_index = make_edges_df(mit_index, image_modality, mask_modality)
-
+    # Get directory the index folder is in to prepend to the image and mask file paths
+    mit_image_dir_path = Path(mit_index_path.parent.stem)
 
     # Set up the data from the mit index to point to the original images for feature extraction
     return pd.DataFrame(data={"SampleID": mit_edges_index.apply(lambda x: f"{x.PatientID}_{str(x.SampleNumber).zfill(4)}", axis=1),
-                              "Image": mit_edges_index.apply(lambda x: f"{Path(f'mit_{dataset_name}') / x.filepath_image}", axis=1),
-                              "Mask": mit_edges_index.apply(lambda x: f"{Path(f'mit_{dataset_name}') / x.filepath_mask}", axis=1),
+                              "Image": mit_edges_index.apply(lambda x: f"{mit_image_dir_path / x.filepath_image}", axis=1),
+                              "Mask": mit_edges_index.apply(lambda x: f"{mit_image_dir_path / x.filepath_mask}", axis=1),
                               "DatasetName": dataset_name,
                               "SeriesInstanceUID_Image": mit_edges_index['SeriesInstanceUID_image'],
                               "Modality_Image": mit_edges_index['Modality_image'],
@@ -92,7 +93,8 @@ def get_mit_extraction_index(dataset_config: dict,
 
 
 def get_readii_extraction_index(dataset_config: dict,
-                                readii_index_path: Path
+                                readii_index_path: Path,
+                                mit_index_path: Path | None = None
                                 ) -> pd.DataFrame:
     """Set up readii index dataframe for feature extraction on READII processed images using the index file generated from negative control generation.
     
@@ -101,12 +103,14 @@ def get_readii_extraction_index(dataset_config: dict,
     dataset_config : dict
         Configuration settings for a dataset, loaded with loadImageDatasetConfig
     readii_index : pd.DataFrame
-        Dataframe containing metadata for the images and masks processed by READII make_negative_controls
-    
+        DataFrame containing metadata for the images and masks processed by READII make_negative_controls
+    mit_index : pd.DataFrame | None
+        DataFrame containing metadata for the MIT processed images and masks
+
     Returns
     -------
     base_index : pd.DataFrame
-        Dataframe with columns:
+        DataFrame with columns:
         * SampleID: PatientID + SampleNumber from imgtools autopipeline
         * Image - path to the image nifti file
         * Mask - path to the mask nifti file
@@ -147,10 +151,13 @@ def get_readii_extraction_index(dataset_config: dict,
 
     image_modality = dataset_config["MIT"]["MODALITIES"]["image"]
     mask_modality = dataset_config["MIT"]["MODALITIES"]["mask"]
+
+    readii_image_dir_path = Path(readii_index_path.parent.stem)
+    mit_image_dir_path = Path(mit_index_path.parent.stem) if mit_index_path is not None else Path(f'mit_{dataset_name}')
     
     return pd.DataFrame(data={"SampleID": settings_readii_index.SampleID,
-                              "Image": settings_readii_index.apply(lambda x: f"{Path(f'readii_{dataset_name}') / x.filepath}", axis=1),
-                              "Mask": settings_readii_index.apply(lambda x: f"{Path(f'mit_{dataset_name}') / x.SampleID / f'{x.MaskID}.nii.gz'}", axis=1),
+                              "Image": settings_readii_index.apply(lambda x: f"{readii_image_dir_path / x.filepath}", axis=1),
+                              "Mask": settings_readii_index.apply(lambda x: f"{mit_image_dir_path / x.SampleID / f'{x.MaskID}.nii.gz'}", axis=1),
                               "DatasetName": dataset_name,
                               "SeriesInstanceUID_Image": "",
                               "Modality_Image": image_modality,


### PR DESCRIPTION
Simple script to run PyRadiomics feature extraction without all of the READII negative controls and non-R2R filepath restrictions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line workflow to extract pyradiomics features from a dataset and save them to a combined CSV.
  * Feature extraction now supports configurable output locations, making it easier to organize generated files.

* **Bug Fixes**
  * Improved path handling for image and mask files when building extraction inputs.
  * Added better alignment between image and mask origins to help avoid extraction mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->